### PR TITLE
Migrate to PHP7

### DIFF
--- a/1.8/gw_addon/multilingual_vars.php
+++ b/1.8/gw_addon/multilingual_vars.php
@@ -5,7 +5,7 @@ if (!defined('IN_GW'))
 }
 /**
  *  Glossword - glossary compiler (http://glossword.info/dev/)
- *  © 2002-2006 Dmitry N. Shilnikov <dev at glossword dot info>
+ *  Â© 2002-2006 Dmitry N. Shilnikov <dev at glossword dot info>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -21,7 +21,7 @@ if (!defined('IN_GW'))
 /* */
 function gw_addon_multilingual_vars_load($filename = '', $obj_tpl)
 {
-	global $oFunc, $$obj_tpl;
+	global $oFunc, ${$obj_tpl};
 	global $sys, $gw_this, $arDictParam;
 
 	// Read additional template variables

--- a/1.8/gw_admin.php
+++ b/1.8/gw_admin.php
@@ -62,7 +62,7 @@ $oHtml->id_sess_name = GW_SID;
  * Register global variables
  * ----------------------------------------------------- */
 $gw_this['vars'] = $oGlobals->register(array(
-	'arControl','arPost','arPre','d','in','file_location','note_afterpost','error_afterpost',
+	'arControl','arPost','arPre','d','in','file_location','note_afterpost',
 	GW_ACTION,GW_SID,GW_SID.'r',GW_TARGET,GW_LANG_I,GW_LANG_C,'visualtheme','uri',
 	'id','uid','isConfirm',GW_A_SEARCH,'id_srch','is','name','email','id_topic',
 	'isUpdate','mode','p','post','remove','q','strict','submit','tid','w1','w2','w3',
@@ -198,7 +198,7 @@ include_once( $sys['path_include'] . '/func.admin.inc.php');
 include_once( $sys['path_include'] . '/class.confirm.php');
 /* Uppercase / lowercase */
 $oCase = new gwv_casemap(array(1,2,3,4,5,6,7,8), array(1,2,3,4,5));
-$oCase->set_replace_sp(array('--'=>' ', '-' => ' ','['=>'[',']'=>']'));
+$oCase->set_replace_sp(array('--' => ' ', '-' => ' '));
 $oCase->encoding = $sys['internal_encoding'];
 $oCase->is_use_mbstring = 1;
 
@@ -342,11 +342,9 @@ if ($oSess->is('is-users'))
 }
 $oTpl->addVal( 'l:term',             $oL->m('term') );
 /* Show notice */
-if ($gw_this['vars']['note_afterpost']) {
+if ($gw_this['vars']['note_afterpost'])
+{
 	$oTpl->addVal( 'v:note_afterpost', gw_get_note_afterpost($gw_this['vars']['note_afterpost'], true) );
-}
-if ($gw_this['vars']['error_afterpost']) {
-	$oTpl->addVal( 'v:note_afterpost', gw_get_note_afterpost($gw_this['vars']['error_afterpost'], false ) );
 }
 
 /* I request you to retain the copyright notice! */
@@ -703,8 +701,7 @@ $sys['path_component_action'] = $sys['path_addon'].'/'.$gw_this['vars'][GW_TARGE
 #prn_r( $sys['path_component']  );
 #prn_r( $sys['path_component_action']  );
 
-$sys['id_current_status'] = '2_page_' . $gw_this['vars'][GW_TARGET] . '_' . $gw_this['vars'][GW_ACTION];
-$sys['id_current_status'] = preg_replace( '/[^a-z0-9_\-]/', '', $sys['id_current_status'] );
+$sys['id_current_status'] = '2_page_'.$gw_this['vars'][GW_TARGET] . '_' . $gw_this['vars'][GW_ACTION];
 
 /* include components */
 if ($gw_this['vars'][GW_TARGET] != '')
@@ -724,7 +721,7 @@ if ($gw_this['vars'][GW_TARGET] != '')
 	file_exists($pathAction)
 		? include_once($pathAction)
 		: (isset($gw_this['class_'.$gw_this['vars'][GW_TARGET]])
-			? $$gw_this['vars'][GW_TARGET] = new $gw_this['class_'.$gw_this['vars'][GW_TARGET]]
+			? ${$gw_this['vars'][GW_TARGET]} = new $gw_this['class_'.$gw_this['vars'][GW_TARGET]]
 			: '' );
 }
 

--- a/1.8/inc/class.gw_htmlforms.php
+++ b/1.8/inc/class.gw_htmlforms.php
@@ -530,7 +530,7 @@ $tmp['strform'] .= '/*]]>*/</script>';
 		{
 			$tmp['cur_element'] = 'arTrns';
 		}
-		$tmp['cur_array'] = $this->$tmp['cur_element'];
+		$tmp['cur_array'] = $this->{$tmp['cur_element']};
 
 		$tmp['arEl'] = isset($this->arEl[$fieldname][$ar['elK']]) ? $this->arEl[$fieldname][$ar['elK']] : array();
 		//

--- a/1.8/inc/class.template.ext.php
+++ b/1.8/inc/class.template.ext.php
@@ -142,7 +142,7 @@ class pch_template extends gwv_template
 					if (strstr($tmp['cmd'], ' '))
 					{
 						$arCmdParts = explode(' ', $tmp['cmd']);
-						$arRpl[] = $this->oCmd->$arCmdParts[0]($arCmdParts[1]);
+						$arRpl[] = $this->oCmd->{$arCmdParts[0]}($arCmdParts[1]);
 					}
 					elseif (substr($tmp['cmd'], 0, 1) == "/")
 					{

--- a/1.8/lib/class.timer.php
+++ b/1.8/lib/class.timer.php
@@ -1,8 +1,8 @@
 <?php 
 /**
  *  Glossword - glossary compiler (http://glossword.biz/)
- *  © 2008 Glossword.biz team
- *  © 2003-2004 Dmitry N. Shilnikov <dev at glossword dot info>
+ *  Â© 2008 Glossword.biz team
+ *  Â© 2003-2004 Dmitry N. Shilnikov <dev at glossword dot info>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@ class gw_timer {
 	{
 		$this->prefix = $prefix;
 		$var = $this->prefix.'_starttime';
-		global $$var;
+		global ${$var};
 		$mtime = explode(' ', microtime());
 		$$var = (float)$mtime[1] + (float)$mtime[0];
 	}

--- a/1.8/lib/class.tpl.php
+++ b/1.8/lib/class.tpl.php
@@ -231,7 +231,7 @@ class gwv_template
 					if (strstr($tmp['cmd'], ' ')) /* not a variable */
 					{
 						$arCmdParts = explode(' ', $tmp['cmd']);
-						$arRpl[] = $this->oCmd->$arCmdParts[0]($arCmdParts[1]);
+						$arRpl[] = $this->oCmd->{$arCmdParts[0]}($arCmdParts[1]);
 					}
 					elseif (substr($tmp['cmd'], 0, 1) == "/") /* block */
 					{

--- a/README.markdown
+++ b/README.markdown
@@ -6,3 +6,14 @@ Glossword is the software to create and publish online multilingual dictionary, 
 <http://glossword.biz/>
 
 Stand-alone version with the latest updates.
+
+Update to PHP 7
+---------------
+This fork has been provisionally fixed to work with PHP 7.1.x and below.
+
+Not yet fixed
+-------------
+- installation/* so new installation on php7 not possible yet. All changes relevant only for live sites.
+- old to new class constructors
+- arrayValueByReference
+- funcGetArg


### PR DESCRIPTION
I have fixed these files to work with PHP 7.1.x and below.

**Not yet fixed**
- installation/* so new installation on php7 not possible yet. All changes relevant only for live sites.
- old to new class constructors
- arrayValueByReference
- funcGetArg
- each() has been removed in PHP 7.2
