### PR TITLE
Fix PHP 8 fatal error in css.php host detection

### DIFF
--- a/1.8/css.php
+++ b/1.8/css.php
@@ -50,8 +50,8 @@ if (!isset($sys['server_host']))
 {
 	$sys['server_host'] = isset($_SERVER["HTTP_HOST"])&&!empty($_SERVER["HTTP_HOST"]) ? $_SERVER["HTTP_HOST"]
 					: (isset($HTTP_SERVER_VARS["HTTP_HOST"]) ? $HTTP_SERVER_VARS["HTTP_HOST"]
-					: (getenv('SERVER_NAME') != '') ? getenv('SERVER_NAME')
-					: 'localhost');
+					: ((getenv('SERVER_NAME') != '') ? getenv('SERVER_NAME')
+					: 'localhost'));
 }
 /* Constants */
 define('CRLF', "\r\n");


### PR DESCRIPTION
### Motivation
- Resolve a PHP 8 parse error caused by an unparenthesized nested ternary when computing `$sys['server_host']` in `1.8/css.php`.

### Description
- Add explicit parentheses around the nested ternary fallback in `1.8/css.php` so the expression evaluates as `... : ((getenv('SERVER_NAME') != '') ? getenv('SERVER_NAME') : 'localhost')`, preserving the original fallback logic.

### Testing
- Ran `php -l 1.8/*.php` which previously failed on `1.8/css.php` due to the parse error and now reports `No syntax errors detected` for the files in `1.8/`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b189e8e9508325ac927fe98bb9212e)