### PR TITLE
Harden routing inputs and admin component loading

### DIFF
--- a/1.8/gw_admin.php
+++ b/1.8/gw_admin.php
@@ -81,6 +81,13 @@ $oGlobals->do_default($gw_this['vars'][GW_LANG_C], $gw_this['vars'][GW_LANG_I]);
 $oGlobals->do_default($gw_this['vars']['lang_enc'], $sys['locale_name']);
 $oGlobals->do_default($gw_this['vars']['visualtheme'], $sys['visualtheme']);
 $oGlobals->do_default($gw_this['vars']['uri'], '');
+
+/* Security: normalize request routing arguments */
+$gw_this['vars'][GW_ACTION] = strtolower(trim($gw_this['vars'][GW_ACTION]));
+$gw_this['vars'][GW_TARGET] = strtolower(trim($gw_this['vars'][GW_TARGET]));
+$gw_this['vars'][GW_ACTION] = preg_replace('/[^a-z0-9_\-]/', '', $gw_this['vars'][GW_ACTION]);
+$gw_this['vars'][GW_TARGET] = preg_replace('/[^a-z0-9_\-]/', '', $gw_this['vars'][GW_TARGET]);
+
 /* used for Session class */
 $sys['uri'] =& $gw_this['vars']['uri'];
 
@@ -706,6 +713,16 @@ $sys['path_component_action'] = $sys['path_addon'].'/'.$gw_this['vars'][GW_TARGE
 $sys['id_current_status'] = '2_page_' . $gw_this['vars'][GW_TARGET] . '_' . $gw_this['vars'][GW_ACTION];
 $sys['id_current_status'] = preg_replace( '/[^a-z0-9_\-]/', '', $sys['id_current_status'] );
 
+/* Security: allow only known administration components */
+$gw_this['vars']['is_valid_component'] = isset($gw_this['ar_actions_list'][$gw_this['vars'][GW_TARGET]]) ? 1 : 0;
+if ($gw_this['vars'][GW_TARGET] != '' && !$gw_this['vars']['is_valid_component'])
+{
+	$gw_this['vars'][GW_TARGET] = '';
+	$gw_this['vars'][GW_ACTION] = '';
+	$sys['path_component'] = '';
+	$sys['path_component_action'] = '';
+}
+
 /* include components */
 if ($gw_this['vars'][GW_TARGET] != '')
 {
@@ -720,7 +737,6 @@ if ($gw_this['vars'][GW_TARGET] != '')
 #		? include_once($sys['path_component_action'] )
 #		: '';
 	/* Old */
-	print $pathAction;
 	file_exists($pathAction)
 		? include_once($pathAction)
 		: (isset($gw_this['class_'.$gw_this['vars'][GW_TARGET]])

--- a/1.8/inc/constructor.inc.php
+++ b/1.8/inc/constructor.inc.php
@@ -149,6 +149,7 @@ for ( reset( $sys['ar_url_append'] ); list($k, $v) = each( $sys['ar_url_append']
 $oTpl->addVal( 'v:input_url_append', $tmp['input_url_append'] );
 
 /* Load addons */
+$gw_this['vars'][GW_TARGET] = preg_replace('/[^a-z0-9_\-]/', '', strtolower($gw_this['vars'][GW_TARGET]));
 $sys['path_component'] = $sys['path_addon'] . '/' . $gw_this['vars'][GW_TARGET] . '/' . $gw_this['vars'][GW_TARGET] . '.php';
 
 file_exists( $sys['path_component'] ) ? include_once($sys['path_component'] ) : '';

--- a/1.8/inc/query_storage.php
+++ b/1.8/inc/query_storage.php
@@ -26,9 +26,12 @@ class gwtk_query_storage extends gw_query_storage
         global $gw_this, $sys;
         $arSql = array();
         foreach ($ar as $k => $v) {
-            if (file_exists($sys['path_addon'] . '/' . $gw_this['vars'][GW_TARGET] . '/' . $v . $this->str_suffix . '.php')) {
+            $target = preg_replace('/[^a-z0-9_\-]/', '', strtolower($gw_this['vars'][GW_TARGET]));
+            $query_file = preg_replace('/[^a-z0-9_\-]/', '', strtolower($v));
+            $path = $sys['path_addon'] . '/' . $target . '/' . $query_file . $this->str_suffix . '.php';
+            if (file_exists($path)) {
                 $tmp = array();
-                include($sys['path_addon'] . '/' . $gw_this['vars'][GW_TARGET] . '/' . $v . $this->str_suffix . '.php');
+                include($path);
                 $arSql = array_merge($arSql, $tmp['ar_queries']);
             }
         }

--- a/1.8/index.php
+++ b/1.8/index.php
@@ -134,6 +134,12 @@ $oGlobals->do_default($gw_this['vars']['lang_enc'], $sys['locale_name']);
 $oGlobals->do_default($gw_this['vars']['p'], 1);
 $oGlobals->do_default($gw_this['vars']['d'], 0);
 $oGlobals->do_default($gw_this['vars']['uri'], '');
+
+/* Security: normalize request routing arguments */
+$gw_this['vars'][GW_ACTION] = strtolower(trim($gw_this['vars'][GW_ACTION]));
+$gw_this['vars'][GW_TARGET] = strtolower(trim($gw_this['vars'][GW_TARGET]));
+$gw_this['vars'][GW_ACTION] = preg_replace('/[^a-z0-9_\-]/', '', $gw_this['vars'][GW_ACTION]);
+$gw_this['vars'][GW_TARGET] = preg_replace('/[^a-z0-9_\-]/', '', $gw_this['vars'][GW_TARGET]);
 /* used for Session class */
 $sys['uri'] =& $gw_this['vars']['uri'];
 


### PR DESCRIPTION
### Motivation
- Prevent request-controlled path traversal / local file inclusion by validating routing inputs before they are used to build include paths. 
- Reduce information leakage and accidental exposure of internal include paths in the admin flow. 
- Ensure only known/authorized admin components are loadable to harden admin-area attack surface.

### Description
- Normalize and sanitize routing arguments `GW_ACTION` and `GW_TARGET` (lowercase, trim, allow only `[a-z0-9_-]`) in `1.8/index.php`, `1.8/gw_admin.php`, and `1.8/inc/constructor.inc.php` using `strtolower`, `trim`, and `preg_replace`. 
- Restrict admin component loading in `1.8/gw_admin.php` by checking the requested `GW_TARGET` against the prepared `ar_actions_list` and clearing `GW_TARGET`/`GW_ACTION` and component include paths if the component is not recognized. 
- Sanitize addon include path segments in `1.8/inc/query_storage.php` by lowercasing and `preg_replace`-filtering both the target and query filename and building the include `path` variable before using `include()`. 
- Sanitize the frontend addon `GW_TARGET` in `1.8/inc/constructor.inc.php` before computing `path_component` and including it. 
- Remove the unintended `print $pathAction` debug output from the admin flow which exposed internal include paths.

### Testing
- Ran PHP syntax checks with `php -l` on modified files: `php -l 1.8/index.php`, `php -l 1.8/gw_admin.php`, `php -l 1.8/inc/query_storage.php`, and `php -l 1.8/inc/constructor.inc.php`, and all returned "No syntax errors detected". 
- Performed a quick repository diff inspection to verify the added sanitation and component gating logic were applied to the intended locations and that the debug print was removed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b18b9a4fac8325804c3b0947a00bac)